### PR TITLE
Implemented Reducer phase functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ in input File is the middle of a word.
 ### Abdul
 - spawn mappers processes and run 'mapper' executable using exec
 - wait for all children to complete execution
+- Added github actions to autobuild project
+- Implemented Reducer phase
 - Update Readme
    - How to compile the program
    - Any assumptions outside this document

--- a/src/mapper.c
+++ b/src/mapper.c
@@ -1,5 +1,6 @@
 #include "mapper.h"
 
+// Instance variable to keep track of root node.
 intermediateDS *DS = NULL;
 
 // combined value list corresponding to a word <1,1,1,1....>

--- a/src/reducer.c
+++ b/src/reducer.c
@@ -81,8 +81,6 @@ void writeFinalDS(int reducerID){
 	// Setup file and filepath needed to create files
 	FILE *outputFd;
 	char filepath[MAXKEYSZ];
-	int pathLength = 50;
-	int createdPathLength = 0;
 
 	// Create temp pointer to root node in tree
 	finalKeyValueDS* tempDS = DS;

--- a/src/reducer.c
+++ b/src/reducer.c
@@ -1,5 +1,7 @@
 #include "reducer.h"
 
+finalKeyValueDS *DS;
+
 // create a key value node
 finalKeyValueDS *createFinalKeyValueNode(char *word, int count){
 	finalKeyValueDS *newNode = (finalKeyValueDS *)malloc (sizeof(finalKeyValueDS));
@@ -43,13 +45,69 @@ void freeFinalDS(finalKeyValueDS *root) {
 
 // reduce function
 void reduce(char *key) {
+	// setup to read words and counts
+	int wordCount =0; // Counts 1's after word
+	char word[MAXKEYSZ]; // Word is stored here
+	int numb; // Temp variable for scannning 1s
+	FILE *inputfd; // File input
+	
+	// Open file
+	inputfd = fopen(key, "r");
+	// Exit and print error if unable to open file
+	if(inputfd == NULL){
+		printf("Error: Unable to open map file %s", key);
+		exit(0);
+	}
 
+	// Fetch word
+	fscanf(inputfd, "%s", word);
+	
+	// Loop until end of file and count 1's
+	while(fscanf(inputfd, "%d", &numb) != EOF){
+		wordCount++;
+	}
+
+	// Close file
+	fclose(inputfd);
+
+    // //update the node with new word count
+    DS = insertNewKeyValue(DS, word, wordCount);
 }
 
 // write the contents of the final intermediate structure
 // to output/ReduceOut/Reduce_reducerID.txt
 void writeFinalDS(int reducerID){
+	// Setup file and filepath needed to create files
+	FILE *outputFd;
+	char filepath[MAXKEYSZ];
+	int pathLength = 50;
+	int createdPathLength = 0;
+
+	// Create temp pointer to root node in tree
+	finalKeyValueDS* tempDS = DS;
+
+	// Update file name given the reducerID
+	sprintf(filepath, "./output/ReduceOut/Reducer_%d.txt", reducerID);
 	
+	// Opening file, and printing error if unable to open/create file 
+	outputFd = fopen(filepath, "w");
+	if(outputFd == NULL){
+		printf("Error: Unable to open reducer file %s", filepath);
+		exit(0);
+	}
+
+	// loop through tree and write to reducer files
+	while(tempDS != NULL)
+    {
+        // write the word and it's count value then move to next pointer.
+        fprintf(outputFd, "%s %d\n", tempDS -> key, tempDS -> value);
+        tempDS = tempDS -> next;
+    }
+
+	// Close file and free pointers
+    fclose(outputFd);
+    freeFinalDS(tempDS);
+	freeFinalDS(DS);
 }
 
 int main(int argc, char *argv[]) {

--- a/src/reducer.c
+++ b/src/reducer.c
@@ -1,5 +1,6 @@
 #include "reducer.h"
 
+// Instance variable to keep track of root node.
 finalKeyValueDS *DS;
 
 // create a key value node


### PR DESCRIPTION
# Reducer Phase Summary
In this phase the master process will be sending the paths of `word.txt` to the reducers based on a hash
function. This means files with same names across different `Map_mapperID` folders will be going to the same
reducer. Once the reducer receives the file path, it passes it to the `reduce()`. The `reduce()` function calculates
the total count for the word from the file contents and stores it in an intermediate structure provided in `reducer.h` and `reducer.c`. The same process is repeated for all the `word.txt` files. Once all the files are
processed, the reducer will then emit the “word count” results to a single file `Reduce_reducerID.txt`.

# To do
- Implement the `reduce(char *key)` function
- Implement `writeFinalDS(int reducerID)`, write the contents of the final intermediate structure to `output/ReduceOut/Reduce_reducerID.txt`
- Update Readme
- Update comments